### PR TITLE
Save dock content as pdf/html file

### DIFF
--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -17,8 +17,8 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QIcon
 from qgis.PyQt.QtWebKitWidgets import QWebPage
-from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMenu, QToolButton
-from qgis.PyQt.QtPrintSupport import QPrinter
+from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMenu, QToolButton, QFileDialog, QDialog
+from qgis.PyQt.QtPrintSupport import QPrinter, QPrintDialog
 from qgis.utils import iface
 
 from functools import partial
@@ -101,8 +101,10 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
         if output_format == 'pdf':
             printer = QPrinter()
             printer.setOutputFormat(QPrinter.PdfFormat)
-            printer.setOutputFileName('test.html')
-            self.viewer.print(printer)
+            printer.setOutputFileName('exampleFile.pdf')
+            dialog = QPrintDialog(printer, self)
+            if dialog.exec_() == QDialog.Accepted:
+                self.viewer.print(printer)
 
     def save_auto_open_dock(self):
         """ Save settings about the dock. """

--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -45,6 +45,10 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
         self.external_help.setText('')
         self.external_help.setIcon(QIcon(QgsApplication.iconPath('mActionHelpContents.svg')))
         self.external_help.clicked.connect(self.open_external_help)
+        self.save_button.setText('')
+        self.save_button.setIcon(QIcon(QgsApplication.iconPath('mActionFileSave.svg')))
+        self.save_button.setToolTip(tr("Save metadata"))
+        self.config.setPopupMode(QToolButton.InstantPopup)
         self.viewer.page().setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
         self.viewer.page().linkClicked.connect(self.open_link)
 

--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -17,7 +17,7 @@ from qgis.core import (
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QIcon
 from qgis.PyQt.QtWebKitWidgets import QWebPage
-from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMenu, QToolButton, QFileDialog, QDialog
+from qgis.PyQt.QtWidgets import QAction, QDockWidget, QMenu, QToolButton, QDialog, QFileDialog
 from qgis.PyQt.QtPrintSupport import QPrinter, QPrintDialog
 from qgis.utils import iface
 
@@ -105,6 +105,19 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
             dialog = QPrintDialog(printer, self)
             if dialog.exec_() == QDialog.Accepted:
                 self.viewer.print(printer)
+        elif output_format == 'html':
+            html_str = self.viewer.page().currentFrame().toHtml()
+            file = QFileDialog.getSaveFileName(
+                self,
+                tr("Save File"),
+                "/home/untitled.html",
+                tr("HTML(*.html)")
+            )
+
+            if file[0] != '':
+                Html_file = open(file[0], "w")
+                Html_file.write(html_str)
+                Html_file.close()
 
     def save_auto_open_dock(self):
         """ Save settings about the dock. """

--- a/pg_metadata/resources/ui/dock.ui
+++ b/pg_metadata/resources/ui/dock.ui
@@ -41,6 +41,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="save_button">
+        <property name="text">
+         <string notr="true">help</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="external_help">
         <property name="text">
          <string notr="true">help</string>

--- a/pg_metadata/resources/ui/dock.ui
+++ b/pg_metadata/resources/ui/dock.ui
@@ -41,9 +41,9 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="save_button">
+       <widget class="QToolButton" name="save_button">
         <property name="text">
-         <string notr="true">help</string>
+         <string notr="true">...</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : #18 
Done: 
  * Adding menu with 2 choice to save as pdf or save as html
  * Export PDF with QPrinter
  * Export HTML