### PR TITLE
Fix bug path export PDF/HTML

### DIFF
--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -113,7 +113,7 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
             output_file = QFileDialog.getSaveFileName(
                 self,
                 tr("Save File as PDF"),
-                self.settings.value("UI/lastFileNameWidgetDir") + layer_name + '.pdf',
+                os.path.join(self.settings.value("UI/lastFileNameWidgetDir"), layer_name + '.pdf'),
                 tr("PDF(*.pdf)")
             )
 
@@ -131,7 +131,7 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
             output_file = QFileDialog.getSaveFileName(
                 self,
                 tr("Save File as HTML"),
-                self.settings.value("UI/lastFileNameWidgetDir") + layer_name + '.html',
+                os.path.join(self.settings.value("UI/lastFileNameWidgetDir"), layer_name + '.html'),
                 tr("HTML(*.html)")
             )
 


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : #44 
* Adding os.path.join when set the path with `UI/lastFileNameWidgetDir`
