### PR TITLE
Tests - Add translation test about glossary

### DIFF
--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -182,7 +182,7 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
                 continue
 
             locale = QgsSettings().value("locale/userLocale", QLocale().name())
-            locale = locale.split('_')[0]
+            locale = locale.split('_')[0].lower()
 
             sql = (
                 "SELECT pgmetadata.get_dataset_item_html_content('{schema}', '{table}', '{locale}');"


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : #20 
* Add translation test about glossary

@mdouchin you wrote

> use the new version of the function SELECT pgmetadata.get_dataset_item_html_content('{schema}', '{table}', '{locale}'); with a try / catch (and use the old one if the first failed SELECT pgmetadata.get_dataset_item_html_content('{schema}', '{table}');

If the language does not exist, the query is not failing @mdouchin, only the content is empty. So it does not make it easy to know if the language is supported for now.

What would be the behavior you wanted ?