### PR TITLE
SQL - Fix wrong type column in export catalog

### DIFF
--- a/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
+++ b/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
@@ -121,7 +121,7 @@ COMMENT ON FUNCTION pgmetadata.calculate_fields_from_data() IS 'Update some fiel
 
 
 -- export_datasets_as_flat_table(text)
-CREATE FUNCTION pgmetadata.export_datasets_as_flat_table(_locale text) RETURNS TABLE(uid uuid, table_name text, schema_name text, title text, abstract text, categories text, themes text, keywords text, spatial_level text, minimum_optimal_scale integer, maximum_optimal_scale integer, publication_date timestamp without time zone, publication_frequency text, license text, confidentiality text, feature_count integer, geometry_type text, projection_name text, projection_authid text, spatial_extent text, creation_date timestamp without time zone, update_date timestamp without time zone, data_last_update timestamp without time zone, links text, contacts text)
+CREATE FUNCTION pgmetadata.export_datasets_as_flat_table(_locale text) RETURNS TABLE(uid uuid, table_name text, schema_name text, title text, abstract text, categories text, themes text, keywords text, spatial_level text, minimum_optimal_scale text, maximum_optimal_scale text, publication_date timestamp without time zone, publication_frequency text, license text, confidentiality text, feature_count integer, geometry_type text, projection_name text, projection_authid text, spatial_extent text, creation_date timestamp without time zone, update_date timestamp without time zone, data_last_update timestamp without time zone, links text, contacts text)
     LANGUAGE plpgsql
     AS $$
 DECLARE

--- a/pg_metadata/install/sql/upgrade/upgrade_to_0.4.1.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_0.4.1.sql
@@ -318,7 +318,7 @@ CREATE OR REPLACE FUNCTION pgmetadata.export_datasets_as_flat_table(_locale text
     uid uuid, table_name text, schema_name text,
     title text, abstract text,
     categories text, themes text, keywords text,
-    spatial_level text, minimum_optimal_scale integer, maximum_optimal_scale integer,
+    spatial_level text, minimum_optimal_scale text, maximum_optimal_scale text,
     publication_date timestamp without time zone, publication_frequency text,
     license text, confidentiality text,
     feature_count integer, geometry_type text, projection_name text, projection_authid text, spatial_extent text,


### PR DESCRIPTION
* Ticket : #60

```sql
SELECT * FROM pgmetadata.export_datasets_as_flat_table('fr');

ERROR:  structure of query does not match function result type
DETAIL:  Returned type text does not match expected type integer in column 10.
CONTEXT:  PL/pgSQL function pgmetadata.export_datasets_as_flat_table(text) line 22 at RETURN QUERY
SQL state: 42804
```

No test, no glory 😈 😉
