### PR TITLE
Add tr() to 2 message strings

### DIFF
--- a/pg_metadata/locator.py
+++ b/pg_metadata/locator.py
@@ -141,5 +141,5 @@ class LocatorFilter(QgsLocatorFilter):
 
         self.iface.messageBar().pushSuccess(
             "PgMetadata",
-            "Layer {} has been loaded.".format(result.displayString),
+            tr("Layer {} has been loaded.").format(result.displayString),
         )

--- a/pg_metadata/processing/administration/set_connections.py
+++ b/pg_metadata/processing/administration/set_connections.py
@@ -50,7 +50,7 @@ class SetConnectionDatabase(BaseProcessingAlgorithm):
 
         param = QgsProcessingParameterEnum(
             self.DATABASES,
-            'List of databases to look for metadata',
+            tr('List of databases to look for metadata'),
             options=names,
             defaultValue=existing_connections,
         )


### PR DESCRIPTION
I’ve added `tr()` to 2 messages in locator.py and set_connections.py

If I haven’t overlooked something, every message has a call to `tr()` now.