### PR TITLE
Add missing icons to tools.py for multi/single geometries

### DIFF
--- a/pg_metadata/tools.py
+++ b/pg_metadata/tools.py
@@ -14,13 +14,13 @@ def icon_for_geometry_type(geometry_type: str) -> QIcon():
     if geometry_type == NULL:
         return QgsLayerItem.iconTable()
 
-    elif geometry_type == 'POINT':
+    elif geometry_type in ('POINT', 'MULTIPOINT'):
         return QgsLayerItem.iconPoint()
 
-    elif geometry_type == 'LINESTRING':
+    elif geometry_type in ('LINESTRING', 'MULTILINESTRING'):
         return QgsLayerItem.iconLine()
 
-    elif geometry_type == 'MULTIPOLYGON':
+    elif geometry_type in ('POLYGON', 'MULTIPOLYGON'):
         return QgsLayerItem.iconPolygon()
 
     # Default icon


### PR DESCRIPTION
I’ve encountered a few geometries that aren’t icons assigned to in `tools.py` yet, e.g. MULTIPOINT in addition to POINT.