### PR TITLE
Add “licence attribution” for source reference, licence number etc.

### DIFF
--- a/pg_metadata/install/sql/pgmetadata/20_TABLE_SEQUENCE_DEFAULT.sql
+++ b/pg_metadata/install/sql/pgmetadata/20_TABLE_SEQUENCE_DEFAULT.sql
@@ -75,7 +75,8 @@ CREATE TABLE pgmetadata.dataset (
     update_date timestamp without time zone DEFAULT now(),
     geom public.geometry(Polygon,4326),
     data_last_update timestamp without time zone,
-    themes text[]
+    themes text[],
+    license_attribution text
 );
 
 

--- a/pg_metadata/install/sql/pgmetadata/30_VIEW.sql
+++ b/pg_metadata/install/sql/pgmetadata/30_VIEW.sql
@@ -88,6 +88,7 @@ CREATE VIEW pgmetadata.v_dataset AS
             d.publication_date,
             d.publication_frequency,
             d.license,
+            d.license_attribution,
             d.confidentiality,
             d.feature_count,
             d.geometry_type,
@@ -121,6 +122,7 @@ CREATE VIEW pgmetadata.v_dataset AS
             s.publication_date,
             ((((glossary.dict -> 'dataset.publication_frequency'::text) -> s.publication_frequency) -> 'label'::text) ->> glossary.locale) AS publication_frequency,
             ((((glossary.dict -> 'dataset.license'::text) -> s.license) -> 'label'::text) ->> glossary.locale) AS license,
+            s.license_attribution,
             ((((glossary.dict -> 'dataset.confidentiality'::text) -> s.confidentiality) -> 'label'::text) ->> glossary.locale) AS confidentiality,
             s.feature_count,
             s.geometry_type,
@@ -158,9 +160,10 @@ CREATE VIEW pgmetadata.v_dataset AS
     ss.spatial_extent,
     ss.creation_date,
     ss.update_date,
-    ss.data_last_update
+    ss.data_last_update,
+    ss.license_attribution
    FROM ss
-  GROUP BY ss.id, ss.uid, ss.table_name, ss.schema_name, ss.title, ss.abstract, ss.keywords, ss.spatial_level, ss.minimum_optimal_scale, ss.maximum_optimal_scale, ss.publication_date, ss.publication_frequency, ss.license, ss.confidentiality, ss.feature_count, ss.geometry_type, ss.projection_name, ss.projection_authid, ss.spatial_extent, ss.creation_date, ss.update_date, ss.data_last_update;
+  GROUP BY ss.id, ss.uid, ss.table_name, ss.schema_name, ss.title, ss.abstract, ss.keywords, ss.spatial_level, ss.minimum_optimal_scale, ss.maximum_optimal_scale, ss.publication_date, ss.publication_frequency, ss.license, ss.license_attribution, ss.confidentiality, ss.feature_count, ss.geometry_type, ss.projection_name, ss.projection_authid, ss.spatial_extent, ss.creation_date, ss.update_date, ss.data_last_update;
 
 
 -- VIEW v_dataset

--- a/pg_metadata/install/sql/pgmetadata/70_COMMENT.sql
+++ b/pg_metadata/install/sql/pgmetadata/70_COMMENT.sql
@@ -207,6 +207,10 @@ COMMENT ON COLUMN pgmetadata.dataset.data_last_update IS 'Date of the last modif
 COMMENT ON COLUMN pgmetadata.dataset.themes IS 'List of themes';
 
 
+-- dataset.license_attribution
+COMMENT ON COLUMN pgmetadata.dataset.license_attribution IS 'Attribution, e.g. giving credit for CC-by license, name of licensor, or license number';
+
+
 -- dataset_contact
 COMMENT ON TABLE pgmetadata.dataset_contact IS 'Pivot table between dataset and contacts.';
 

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.1.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.1.0.sql
@@ -221,6 +221,7 @@ INSERT INTO pgmetadata.glossary (id, field, code, label_en, description_en, item
 update pgmetadata.glossary set item_order = item_order + 1
 where field = 'dataset.publication_frequency' and code in ('DAY', 'WEE', 'MON');
 
+
 SELECT pg_catalog.setval('pgmetadata.glossary_id_seq', 136, true);
 
 -- Issue #75, also update "update_date"
@@ -328,111 +329,5 @@ BEGIN
     RETURN NEW;
 END;
 $$;
-
-
--- DATASET
-
--- new fields 
-ALTER TABLE pgmetadata.dataset ADD COLUMN IF NOT EXISTS license_attribution text;
-
-
-CREATE OR REPLACE VIEW pgmetadata.v_dataset AS
- WITH glossary AS (
-         SELECT COALESCE(current_setting('pgmetadata.locale'::text, true), 'en'::text) AS locale,
-            v_glossary.dict
-           FROM pgmetadata.v_glossary
-        ), s AS (
-         SELECT d.id,
-            d.uid,
-            d.table_name,
-            d.schema_name,
-            d.title,
-            d.abstract,
-            d.categories,
-            d.themes,
-            d.keywords,
-            d.spatial_level,
-            d.minimum_optimal_scale,
-            d.maximum_optimal_scale,
-            d.publication_date,
-            d.publication_frequency,
-            d.license,
-            d.license_attribution,
-            d.confidentiality,
-            d.feature_count,
-            d.geometry_type,
-            d.projection_name,
-            d.projection_authid,
-            d.spatial_extent,
-            d.creation_date,
-            d.update_date,
-            d.data_last_update,
-            d.geom,
-            cat.cat,
-            theme.theme
-           FROM ((pgmetadata.dataset d
-             LEFT JOIN LATERAL unnest(d.categories) cat(cat) ON (true))
-             LEFT JOIN LATERAL unnest(d.themes) theme(theme) ON (true))
-          WHERE true
-          ORDER BY d.id
-        ), ss AS (
-         SELECT s.id,
-            s.uid,
-            s.table_name,
-            s.schema_name,
-            s.title,
-            s.abstract,
-            ((((glossary.dict -> 'dataset.categories'::text) -> s.cat) -> 'label'::text) ->> glossary.locale) AS cat,
-            gtheme.label AS theme,
-            s.keywords,
-            s.spatial_level,
-            ('1/'::text || s.minimum_optimal_scale) AS minimum_optimal_scale,
-            ('1/'::text || s.maximum_optimal_scale) AS maximum_optimal_scale,
-            s.publication_date,
-            ((((glossary.dict -> 'dataset.publication_frequency'::text) -> s.publication_frequency) -> 'label'::text) ->> glossary.locale) AS publication_frequency,
-            ((((glossary.dict -> 'dataset.license'::text) -> s.license) -> 'label'::text) ->> glossary.locale) AS license,
-            s.license_attribution,
-            ((((glossary.dict -> 'dataset.confidentiality'::text) -> s.confidentiality) -> 'label'::text) ->> glossary.locale) AS confidentiality,
-            s.feature_count,
-            s.geometry_type,
-            (regexp_split_to_array((rs.srtext)::text, '"'::text))[2] AS projection_name,
-            s.projection_authid,
-            s.spatial_extent,
-            s.creation_date,
-            s.update_date,
-            s.data_last_update
-           FROM glossary,
-            ((s
-             LEFT JOIN pgmetadata.theme gtheme ON ((gtheme.code = s.theme)))
-             LEFT JOIN public.spatial_ref_sys rs ON ((concat(rs.auth_name, ':', rs.auth_srid) = s.projection_authid)))
-        )
- SELECT ss.id,
-    ss.uid,
-    ss.table_name,
-    ss.schema_name,
-    ss.title,
-    ss.abstract,
-    string_agg(DISTINCT ss.cat, ', '::text ORDER BY ss.cat) AS categories,
-    string_agg(DISTINCT ss.theme, ', '::text ORDER BY ss.theme) AS themes,
-    ss.keywords,
-    ss.spatial_level,
-    ss.minimum_optimal_scale,
-    ss.maximum_optimal_scale,
-    ss.publication_date,
-    ss.publication_frequency,
-    ss.license,
-    ss.confidentiality,
-    ss.feature_count,
-    ss.geometry_type,
-    ss.projection_name,
-    ss.projection_authid,
-    ss.spatial_extent,
-    ss.creation_date,
-    ss.update_date,
-    ss.data_last_update,
-    ss.license_attribution
-   FROM ss
-  GROUP BY ss.id, ss.uid, ss.table_name, ss.schema_name, ss.title, ss.abstract, ss.keywords, ss.spatial_level, ss.minimum_optimal_scale, ss.maximum_optimal_scale, ss.publication_date, ss.publication_frequency, ss.license, ss.license_attribution, ss.confidentiality, ss.feature_count, ss.geometry_type, ss.projection_name, ss.projection_authid, ss.spatial_extent, ss.creation_date, ss.update_date, ss.data_last_update;
-
 
 COMMIT;

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.3.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.3.0.sql
@@ -120,6 +120,8 @@ DROP TABLE pgmetadata.t_glossary;
 
 ALTER TABLE pgmetadata.dataset ADD COLUMN IF NOT EXISTS license_attribution text;
 
+COMMENT ON COLUMN pgmetadata.dataset.license_attribution IS 'Attribution, e.g. giving credit for CC-by license, name of licensor, or license number';
+
 CREATE OR REPLACE VIEW pgmetadata.v_dataset AS
  WITH glossary AS (
          SELECT COALESCE(current_setting('pgmetadata.locale'::text, true), 'en'::text) AS locale,

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.3.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.3.0.sql
@@ -113,4 +113,109 @@ WHERE g.field = t.field AND g.code = t.code;
 
 DROP TABLE pgmetadata.t_glossary;
 
+
+-- DATASET
+
+-- new field: license_attribution
+
+ALTER TABLE pgmetadata.dataset ADD COLUMN IF NOT EXISTS license_attribution text;
+
+CREATE OR REPLACE VIEW pgmetadata.v_dataset AS
+ WITH glossary AS (
+         SELECT COALESCE(current_setting('pgmetadata.locale'::text, true), 'en'::text) AS locale,
+            v_glossary.dict
+           FROM pgmetadata.v_glossary
+        ), s AS (
+         SELECT d.id,
+            d.uid,
+            d.table_name,
+            d.schema_name,
+            d.title,
+            d.abstract,
+            d.categories,
+            d.themes,
+            d.keywords,
+            d.spatial_level,
+            d.minimum_optimal_scale,
+            d.maximum_optimal_scale,
+            d.publication_date,
+            d.publication_frequency,
+            d.license,
+            d.license_attribution,
+            d.confidentiality,
+            d.feature_count,
+            d.geometry_type,
+            d.projection_name,
+            d.projection_authid,
+            d.spatial_extent,
+            d.creation_date,
+            d.update_date,
+            d.data_last_update,
+            d.geom,
+            cat.cat,
+            theme.theme
+           FROM ((pgmetadata.dataset d
+             LEFT JOIN LATERAL unnest(d.categories) cat(cat) ON (true))
+             LEFT JOIN LATERAL unnest(d.themes) theme(theme) ON (true))
+          WHERE true
+          ORDER BY d.id
+        ), ss AS (
+         SELECT s.id,
+            s.uid,
+            s.table_name,
+            s.schema_name,
+            s.title,
+            s.abstract,
+            ((((glossary.dict -> 'dataset.categories'::text) -> s.cat) -> 'label'::text) ->> glossary.locale) AS cat,
+            gtheme.label AS theme,
+            s.keywords,
+            s.spatial_level,
+            ('1/'::text || s.minimum_optimal_scale) AS minimum_optimal_scale,
+            ('1/'::text || s.maximum_optimal_scale) AS maximum_optimal_scale,
+            s.publication_date,
+            ((((glossary.dict -> 'dataset.publication_frequency'::text) -> s.publication_frequency) -> 'label'::text) ->> glossary.locale) AS publication_frequency,
+            ((((glossary.dict -> 'dataset.license'::text) -> s.license) -> 'label'::text) ->> glossary.locale) AS license,
+            s.license_attribution,
+            ((((glossary.dict -> 'dataset.confidentiality'::text) -> s.confidentiality) -> 'label'::text) ->> glossary.locale) AS confidentiality,
+            s.feature_count,
+            s.geometry_type,
+            (regexp_split_to_array((rs.srtext)::text, '"'::text))[2] AS projection_name,
+            s.projection_authid,
+            s.spatial_extent,
+            s.creation_date,
+            s.update_date,
+            s.data_last_update
+           FROM glossary,
+            ((s
+             LEFT JOIN pgmetadata.theme gtheme ON ((gtheme.code = s.theme)))
+             LEFT JOIN public.spatial_ref_sys rs ON ((concat(rs.auth_name, ':', rs.auth_srid) = s.projection_authid)))
+        )
+ SELECT ss.id,
+    ss.uid,
+    ss.table_name,
+    ss.schema_name,
+    ss.title,
+    ss.abstract,
+    string_agg(DISTINCT ss.cat, ', '::text ORDER BY ss.cat) AS categories,
+    string_agg(DISTINCT ss.theme, ', '::text ORDER BY ss.theme) AS themes,
+    ss.keywords,
+    ss.spatial_level,
+    ss.minimum_optimal_scale,
+    ss.maximum_optimal_scale,
+    ss.publication_date,
+    ss.publication_frequency,
+    ss.license,
+    ss.confidentiality,
+    ss.feature_count,
+    ss.geometry_type,
+    ss.projection_name,
+    ss.projection_authid,
+    ss.spatial_extent,
+    ss.creation_date,
+    ss.update_date,
+    ss.data_last_update,
+    ss.license_attribution
+   FROM ss
+  GROUP BY ss.id, ss.uid, ss.table_name, ss.schema_name, ss.title, ss.abstract, ss.keywords, ss.spatial_level, ss.minimum_optimal_scale, ss.maximum_optimal_scale, ss.publication_date, ss.publication_frequency, ss.license, ss.license_attribution, ss.confidentiality, ss.feature_count, ss.geometry_type, ss.projection_name, ss.projection_authid, ss.spatial_extent, ss.creation_date, ss.update_date, ss.data_last_update;
+
 COMMIT;

--- a/pg_metadata/resources/html/main.html
+++ b/pg_metadata/resources/html/main.html
@@ -65,6 +65,9 @@
             <th>License</th><td>[% license %]</td>
         </tr>
         <tr>
+            <th>License attribution / number</th><td>[% license_attribution %]</td>
+        </tr>
+        <tr>
             <th>Confidentiality</th><td>[% confidentiality %]</td>
         </tr>
     </table>

--- a/pg_metadata/resources/projects/pg_metadata_administration.qgs
+++ b/pg_metadata/resources/projects/pg_metadata_administration.qgs
@@ -995,6 +995,16 @@ def my_form_open(dialog, layer, feature):
             </config>
           </editWidget>
         </field>
+        <field name="license_attribution" configurationFlags="None">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" type="bool" value="false"></Option>
+                <Option name="UseHtml" type="bool" value="false"></Option>
+              </Option>
+            </config>
+          </editWidget>n
+        </field>
         <field name="confidentiality" configurationFlags="None">
           <editWidget type="ValueRelation">
             <config>
@@ -1150,6 +1160,7 @@ def my_form_open(dialog, layer, feature):
         <alias field="update_date" name="Last updated at" index="21"/>
         <alias field="data_last_update" name="Data last update" index="22"/>
         <alias field="themes" name="Themes" index="23"/>
+        <alias field="license_attribution" name="License attribution" index="24"/>
       </aliases>
       <defaults>
         <default expression="" field="id" applyOnUpdate="0"/>
@@ -1166,6 +1177,7 @@ def my_form_open(dialog, layer, feature):
         <default expression="" field="publication_date" applyOnUpdate="0"/>
         <default expression="" field="publication_frequency" applyOnUpdate="0"/>
         <default expression="" field="license" applyOnUpdate="0"/>
+        <default expression="" field="license_attribution" applyOnUpdate="0"/>
         <default expression="" field="confidentiality" applyOnUpdate="0"/>
         <default expression="" field="feature_count" applyOnUpdate="0"/>
         <default expression="" field="geometry_type" applyOnUpdate="0"/>
@@ -1192,6 +1204,7 @@ def my_form_open(dialog, layer, feature):
         <constraint unique_strength="0" constraints="0" field="publication_date" exp_strength="0" notnull_strength="0"/>
         <constraint unique_strength="0" constraints="0" field="publication_frequency" exp_strength="0" notnull_strength="0"/>
         <constraint unique_strength="0" constraints="0" field="license" exp_strength="0" notnull_strength="0"/>
+        <constraint unique_strength="0" constraints="0" field="license_attribution" exp_strength="0" notnull_strength="0"/>
         <constraint unique_strength="0" constraints="0" field="confidentiality" exp_strength="0" notnull_strength="0"/>
         <constraint unique_strength="0" constraints="0" field="feature_count" exp_strength="0" notnull_strength="0"/>
         <constraint unique_strength="0" constraints="0" field="geometry_type" exp_strength="0" notnull_strength="0"/>
@@ -1218,6 +1231,7 @@ def my_form_open(dialog, layer, feature):
         <constraint field="publication_date" desc="" exp=""/>
         <constraint field="publication_frequency" desc="" exp=""/>
         <constraint field="license" desc="" exp=""/>
+        <constraint field="license_attribution" desc="" exp=""/>
         <constraint field="confidentiality" desc="" exp=""/>
         <constraint field="feature_count" desc="" exp=""/>
         <constraint field="geometry_type" desc="" exp=""/>
@@ -1249,6 +1263,7 @@ def my_form_open(dialog, layer, feature):
           <column type="field" name="publication_date" width="-1" hidden="0"/>
           <column type="field" name="publication_frequency" width="-1" hidden="0"/>
           <column type="field" name="license" width="-1" hidden="0"/>
+          <column type="field" name="license_attribution" width="-1" hidden="0"/>
           <column type="field" name="confidentiality" width="-1" hidden="0"/>
           <column type="field" name="feature_count" width="-1" hidden="0"/>
           <column type="field" name="geometry_type" width="-1" hidden="0"/>
@@ -1308,6 +1323,7 @@ def my_form_open(dialog, layer, feature):
             <attributeEditorField name="publication_date" index="11" showLabel="1"/>
             <attributeEditorField name="publication_frequency" index="12" showLabel="1"/>
             <attributeEditorField name="license" index="13" showLabel="1"/>
+            <attributeEditorField name="license_attribution" index="24" showLabel="1"/>
             <attributeEditorField name="confidentiality" index="14" showLabel="1"/>
           </attributeEditorContainer>
           <attributeEditorContainer groupBox="1" name="Spatial properties" visibilityExpressionEnabled="0" showLabel="1" columnCount="1" visibilityExpression="">
@@ -1343,6 +1359,7 @@ def my_form_open(dialog, layer, feature):
         <field editable="0" name="id"/>
         <field editable="1" name="keywords"/>
         <field editable="1" name="license"/>
+        <field editable="1" name="license_attribution"/>
         <field editable="1" name="maximum_optimal_scale"/>
         <field editable="1" name="minimum_optimal_scale"/>
         <field editable="0" name="projection_authid"/>
@@ -1370,6 +1387,7 @@ def my_form_open(dialog, layer, feature):
         <field name="id" labelOnTop="0"/>
         <field name="keywords" labelOnTop="0"/>
         <field name="license" labelOnTop="0"/>
+        <field name="license_attribution" labelOnTop="0"/>
         <field name="maximum_optimal_scale" labelOnTop="0"/>
         <field name="minimum_optimal_scale" labelOnTop="0"/>
         <field name="projection_authid" labelOnTop="0"/>


### PR DESCRIPTION
New field for license numbers, ODC-BY and German Data Licence attributions etc.
* New database text field `dataset.license_attribution` (I followed American spelling)
* Added field to Dataset attribute form below licence selection in Admin Project
* Added to HTML template

<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
Implements #71

