### PR TITLE
Fix issue #115: preserve backslashes in links when substituting into templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add raster support (contribution from @effjot Florian Jenn)
+* Fix handling of backslashes in file:// links to Windows files (contribution from @effjot Florian Jenn)
 
 ## 1.1.1 - 2022-02-14
 

--- a/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
+++ b/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
@@ -251,7 +251,7 @@ BEGIN
         -- replace QGIS style field [% "my_field" %] by field value
         html = regexp_replace(
             html,
-            concat('\[%( )*?(")*', item.col ,'(")*( )*%\]'),
+            concat('\[% *"?', item.col, '"? *%\]'),
             replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
             'g'
         )
@@ -400,15 +400,15 @@ BEGIN
     -- add contacts: [% "meta_contacts" %]
     html = regexp_replace(
         html,
-        concat('\[%( )*?(")*meta_contacts(")*( )*%\]'),
-        coalesce(html_contact, ''),
+        concat('\[% *"?meta_contacts"? *%\]'),
+        coalesce(replace(html_contact, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 
     -- add links [% "meta_links" %]
     html = regexp_replace(
         html,
-        concat('\[%( )*?(")*meta_links(")*( )*%\]'),
+        concat('\[% *"?meta_links"? *%\]'),
         coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );

--- a/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
+++ b/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
@@ -252,7 +252,7 @@ BEGIN
         html = regexp_replace(
             html,
             concat('\[% *"?', item.col, '"? *%\]'),
-            replace(item.val, $quote$\$quote$, $quote$\\$quote$), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+            replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
             'g'
         )
         ;
@@ -401,7 +401,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_contacts"? *%\]'),
-        coalesce(replace(html_contact, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_contact, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 
@@ -409,7 +409,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_links"? *%\]'),
-        coalesce(replace(html_link, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 

--- a/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
+++ b/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
@@ -252,7 +252,7 @@ BEGIN
         html = regexp_replace(
             html,
             concat('\[%( )*?(")*', item.col ,'(")*( )*%\]'),
-            item.val,
+            replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
             'g'
         )
         ;
@@ -409,7 +409,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[%( )*?(")*meta_links(")*( )*%\]'),
-        coalesce(html_link, ''),
+        coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 

--- a/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
+++ b/pg_metadata/install/sql/pgmetadata/10_FUNCTION.sql
@@ -252,7 +252,7 @@ BEGIN
         html = regexp_replace(
             html,
             concat('\[% *"?', item.col, '"? *%\]'),
-            replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+            replace(item.val, $quote$\$quote$, $quote$\\$quote$), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
             'g'
         )
         ;
@@ -401,7 +401,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_contacts"? *%\]'),
-        coalesce(replace(html_contact, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_contact, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 
@@ -409,7 +409,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_links"? *%\]'),
-        coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_link, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
@@ -227,7 +227,7 @@ BEGIN
         html = regexp_replace(
             html,
             concat('\[% *"?', item.col, '"? *%\]'),
-            replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+            replace(item.val, $quote$\$quote$, $quote$\\$quote$), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
             'g'
         )
         ;
@@ -355,7 +355,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_contacts"? *%\]'),
-        coalesce(replace(html_contact, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_contact, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 
@@ -363,7 +363,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_links"? *%\]'),
-        coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_link, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
@@ -227,7 +227,7 @@ BEGIN
         html = regexp_replace(
             html,
             concat('\[% *"?', item.col, '"? *%\]'),
-            replace(item.val, $quote$\$quote$, $quote$\\$quote$), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+            replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
             'g'
         )
         ;
@@ -355,7 +355,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_contacts"? *%\]'),
-        coalesce(replace(html_contact, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_contact, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 
@@ -363,7 +363,7 @@ BEGIN
     html = regexp_replace(
         html,
         concat('\[% *"?meta_links"? *%\]'),
-        coalesce(replace(html_link, $quote$\$quote$, $quote$\\$quote$), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
         'g'
     );
 

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
@@ -186,21 +186,193 @@ END;
 $$;
 
 
--- FUNCTION update_postgresql_table_comment(table_schema text, table_name text, table_comment text, table_type text)
-COMMENT ON FUNCTION pgmetadata.update_postgresql_table_comment(table_schema text, table_name text, table_comment text, table_type text) IS 'Update the PostgreSQL comment of a table by giving table schema, name and comment
-Example: if you need to update the comments for all the items listed by pgmetadata.v_table_comment_from_metadata:
+-- Issue #115 (fix backslashes in regexp substition for HTML templates)
 
-    SELECT
-    v.table_schema,
-    v.table_name,
-    pgmetadata.update_postgresql_table_comment(
-        v.table_schema,
-        v.table_name,
-        v.table_comment,
-        v.table_type
-    ) AS comment_updated
-    FROM pgmetadata.v_table_comment_from_metadata AS v
+-- generate_html_from_json(json, text)
+DROP FUNCTION IF EXISTS pgmetadata.generate_html_from_json(json, text);
+CREATE OR REPLACE FUNCTION pgmetadata.generate_html_from_json(_json_data json, _template_section text) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    item record;
+    html text;
+BEGIN
 
-    ';
+    -- Get HTML template from html_template table
+    SELECT content
+    FROM pgmetadata.html_template AS h
+    WHERE True
+    AND section = _template_section
+    INTO html
+    ;
+    IF html IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- Get dataset item
+    -- We transpose dataset record into rows such as
+    -- col    | val
+    -- id     | 1
+    -- uid    | dfd3b73c-3cd3-40b7-b92d-aa0f625c86fe
+    -- ...
+    -- title  | My title
+    -- For each row, we search and replace the [% "col" %] by val
+    FOR item IN
+        SELECT (line.d).key AS col, Coalesce((line.d).value, '') AS val
+        FROM (
+            SELECT json_each_text(_json_data) d
+        ) AS line
+    LOOP
+        -- replace QGIS style field [% "my_field" %] by field value
+        html = regexp_replace(
+            html,
+            concat('\[% *"?', item.col, '"? *%\]'),
+            replace(item.val, '\', '\\'), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+            'g'
+        )
+        ;
+
+    END LOOP;
+
+    RETURN html;
+
+END;
+$$;
+
+-- FUNCTION generate_html_from_json(_json_data json, _template_section text)
+COMMENT ON FUNCTION pgmetadata.generate_html_from_json(_json_data json, _template_section text) IS 'Generate HTML content for the given JSON representation of a record and a given section, based on the template stored in the pgmetadata.html_template table. Template section controlled values are "main", "contact" and "link". If the corresponding line is not found in the pgmetadata.html_template table, NULL is returned.';
+
+
+-- get_dataset_item_html_content(text, text, text)
+DROP FUNCTION IF EXISTS get_dataset_item_html_content(text, text, text);
+CREATE OR REPLACE FUNCTION pgmetadata.get_dataset_item_html_content(_table_schema text, _table_name text, _locale text) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    locale_exists boolean;
+    item record;
+    dataset_rec record;
+    sql_text text;
+    json_data json;
+    html text;
+    html_contact text;
+    html_link text;
+    html_main text;
+BEGIN
+    -- Check if dataset exists
+    SELECT *
+    FROM pgmetadata.dataset
+    WHERE True
+    AND schema_name = _table_schema
+    AND table_name = _table_name
+    LIMIT 1
+    INTO dataset_rec
+    ;
+
+    IF dataset_rec.id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- Check if the _locale parameter corresponds to the available locales
+    _locale = lower(_locale);
+    SELECT _locale IN (SELECT locale FROM pgmetadata.v_locales)
+    INTO locale_exists
+    ;
+    IF NOT locale_exists THEN
+        _locale = 'en';
+    END IF;
+
+    -- Set locale
+    -- We must use EXECUTE in order to have _locale to be correctly interpreted
+    sql_text = concat('SET SESSION "pgmetadata.locale" = ', quote_literal(_locale));
+    EXECUTE sql_text;
+
+    -- Contacts
+    html_contact = '';
+    FOR json_data IN
+        WITH a AS (
+            SELECT *
+            FROM pgmetadata.v_contact
+            WHERE True
+            AND schema_name = _table_schema
+            AND table_name = _table_name
+        )
+        SELECT row_to_json(a.*)
+        FROM a
+    LOOP
+        html_contact = concat(
+            html_contact, '
+            ',
+            pgmetadata.generate_html_from_json(json_data, 'contact')
+        );
+    END LOOP;
+    -- RAISE NOTICE 'html_contact: %', html_contact;
+
+    -- Links
+    html_link = '';
+    FOR json_data IN
+        WITH a AS (
+            SELECT *
+            FROM pgmetadata.v_link
+            WHERE True
+            AND schema_name = _table_schema
+            AND table_name = _table_name
+        )
+        SELECT row_to_json(a.*)
+        FROM a
+    LOOP
+        html_link = concat(
+            html_link, '
+            ',
+            pgmetadata.generate_html_from_json(json_data, 'link')
+        );
+    END LOOP;
+    --RAISE NOTICE 'html_link: %', html_link;
+
+    -- Main
+    html_main = '';
+    WITH a AS (
+        SELECT *
+        FROM pgmetadata.v_dataset
+        WHERE True
+        AND schema_name = _table_schema
+        AND table_name = _table_name
+    )
+    SELECT row_to_json(a.*)
+    FROM a
+    INTO json_data
+    ;
+    html_main = pgmetadata.generate_html_from_json(json_data, 'main');
+    -- RAISE NOTICE 'html_main: %', html_main;
+
+    IF html_main IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    html = html_main;
+
+    -- add contacts: [% "meta_contacts" %]
+    html = regexp_replace(
+        html,
+        concat('\[% *"?meta_contacts"? *%\]'),
+        coalesce(replace(html_contact, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        'g'
+    );
+
+    -- add links [% "meta_links" %]
+    html = regexp_replace(
+        html,
+        concat('\[% *"?meta_links"? *%\]'),
+        coalesce(replace(html_link, '\', '\\'), ''), -- escape backslashes in substitution string (\1...\9 refer to subexpressions)
+        'g'
+    );
+
+    RETURN html;
+
+END;
+$$;
+
+COMMENT ON FUNCTION pgmetadata.get_dataset_item_html_content(_table_schema text, _table_name text, _locale text) IS 'Generate the metadata HTML content for the given table and given language or NULL if no templates are stored in the pgmetadata.html_template table.';
+
 
 COMMIT;

--- a/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
+++ b/pg_metadata/install/sql/upgrade/upgrade_to_1.2.0.sql
@@ -185,6 +185,23 @@ BEGIN
 END;
 $$;
 
+-- FUNCTION update_postgresql_table_comment(table_schema text, table_name text, table_comment text, table_type text)
+COMMENT ON FUNCTION pgmetadata.update_postgresql_table_comment(table_schema text, table_name text, table_comment text, table_type text) IS 'Update the PostgreSQL comment of a table by giving table schema, name and comment
+Example: if you need to update the comments for all the items listed by pgmetadata.v_table_comment_from_metadata:
+
+    SELECT
+    v.table_schema,
+    v.table_name,
+    pgmetadata.update_postgresql_table_comment(
+        v.table_schema,
+        v.table_name,
+        v.table_comment,
+        v.table_type
+    ) AS comment_updated
+    FROM pgmetadata.v_table_comment_from_metadata AS v
+
+    ';
+
 
 -- Issue #115 (fix backslashes in regexp substition for HTML templates)
 

--- a/pg_metadata/test/test_sql.py
+++ b/pg_metadata/test/test_sql.py
@@ -96,15 +96,24 @@ class TestSql(DatabaseTestCase):
             'data_last_update': "'2020-12-25T20:35:59'::timestamp",
         }
         return_value = self._insert(dataset_feature, 'dataset', 'id')
-        link_feature = {
-            'name': "'test link'",
+        web_link_feature = {
+            'name': "'test web link'",
             'type': "'file'",
             'url': "'https://metadata.is.good'",
             'description': "''",
             'size': "0.5",
             'fk_id_dataset': "{}".format(return_value[0][0]),
         }
-        self._insert(link_feature, 'link')
+        self._insert(web_link_feature, 'link')
+        file_link_feature = {
+            'name': "'test file link'",
+            'type': "'file'",
+            'url': r"'file:///C:\Users\test\1file.txt'",
+            'description': "''",
+            'size': "0.5",
+            'fk_id_dataset': "{}".format(return_value[0][0]),
+        }
+        self._insert(file_link_feature, 'link')
 
         # Remove previous template to have a smaller one
         sql = "DELETE FROM pgmetadata.html_template WHERE section IN ('main', 'link');"
@@ -124,7 +133,7 @@ class TestSql(DatabaseTestCase):
         self._insert(html_feature, 'html_template')
         html_feature = {
             'section': "'link'",
-            'content': "'<p>[% \"name\" %] [% \"description\" %]</p><p>[% \"size\" %]</p>'",
+            'content': "'<p>[% \"name\" %] [% \"description\" %]</p><p>[% url %] [% \"size\" %]</p>'",
         }
         self._insert(html_feature, 'html_template')
 
@@ -133,7 +142,9 @@ class TestSql(DatabaseTestCase):
         )
         expected = (
             '<p>Test title</p><b>Test abstract.</b><p>2020-12-25T20:35:59</p><p>\n'
-            '            <p>test link </p><p>1</p></p><p>New test theme, test theme</p>'
+            '            <p>test web link </p><p>https://metadata.is.good 1</p>\n'
+            r'            <p>test file link </p><p>file:///C:\Users\test\1file.txt 1</p>'
+            '</p><p>New test theme, test theme</p>'
         )
         self.assertEqual(expected, result[0][0])
 

--- a/pg_metadata/test/test_sql.py
+++ b/pg_metadata/test/test_sql.py
@@ -174,8 +174,8 @@ class TestSql(DatabaseTestCase):
         }
         return_value = self._insert(dataset_feature, 'dataset', 'id, uid')
 
-        link_feature = {
-            'name': "'test link'",
+        web_link_feature = {
+            'name': "'test web link'",
             'type': "'file'",
             'mime': "'pdf'",
             'url': "'https://metadata.is.good'",
@@ -183,8 +183,17 @@ class TestSql(DatabaseTestCase):
             'size': "590",
             'fk_id_dataset': "{}".format(return_value[0][0]),
         }
-        self._insert(link_feature, 'link')
-
+        self._insert(web_link_feature, 'link')
+        file_link_feature = {
+            'name': "'test file link'",
+            'type': "'file'",
+            'mime': "'plain'",
+            'url': r"'file:///C:\Users\test\1file.txt'",
+            'description': "'File description'",
+            'size': "590",
+            'fk_id_dataset': "{}".format(return_value[0][0]),
+        }
+        self._insert(file_link_feature, 'link')
         contact_feature = {
             'name': "'Jane Doe'",
             'organisation_name': "'Acme'",
@@ -265,10 +274,17 @@ class TestSql(DatabaseTestCase):
             '<foaf:mbox>bob.bob@corp.spa</foaf:mbox>'
             '</foaf:Organization></dct:publisher>'
 
-            '<dcat:distribution><dcat:Distribution><dct:title>test link</dct:title>'
+            '<dcat:distribution><dcat:Distribution><dct:title>test web link</dct:title>'
             '<dct:description>Link description</dct:description>'
             '<dcat:downloadURL>https://metadata.is.good</dcat:downloadURL>'
             '<dcat:mediaType>application/pdf</dcat:mediaType><dct:format>a file</dct:format>'
+            '<dct:bytesize>590</dct:bytesize>'
+            '<dct:license>Licence Ouverte Version 2.1</dct:license>'
+            '</dcat:Distribution></dcat:distribution>'
+            '<dcat:distribution><dcat:Distribution><dct:title>test file link</dct:title>'
+            '<dct:description>File description</dct:description>'
+            r'<dcat:downloadURL>file:///C:\Users\test\1file.txt</dcat:downloadURL>'
+            '<dcat:mediaType>text/plain</dcat:mediaType><dct:format>a file</dct:format>'
             '<dct:bytesize>590</dct:bytesize>'
             '<dct:license>Licence Ouverte Version 2.1</dct:license>'
             '</dcat:Distribution></dcat:distribution>'


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : fix #115
* Links to files on Windows got mangled when backslashes precede a number. (The substitution strings for `regexp_replace()` can refer to subexpressions in the match pattern by `\1` … `\9`.)
* This PR escapes backslashes in these substitution strings.
* Also, the regexes have been simplified.

(I apologise for the mess in the last commits. The tests failed and I thought all those quotes and backslashes tripped the tests up. They do in the syntax highlighting of some apps. But I just had forgotten a function comment in the upgrade.sql.)