### PR TITLE
Fix #119 unknown connection names

### DIFF
--- a/pg_metadata/connection_manager.py
+++ b/pg_metadata/connection_manager.py
@@ -85,8 +85,8 @@ def validate_connections_names() -> tuple:
     metadata = QgsProviderRegistry.instance().providerMetadata('postgres')
 
     connection_names = settings_connections_names()
-    if not connection_names:
-        return  # no connections is a valid situation
+    if not connection_names:  # no connections is a valid situation
+        return [], []
 
     valid = []
     invalid = []

--- a/pg_metadata/connection_manager.py
+++ b/pg_metadata/connection_manager.py
@@ -60,6 +60,14 @@ def add_connection(connection_name: str) -> None:
         settings.setValue("pgmetadata/connection_names", new_string)
 
 
+def store_connections(connection_names: list[str]) -> None:
+    """ Store a list of connection names in the QGIS configuration,
+        overwriting existing connections """
+    reset_connections()
+    for name in connection_names:
+        add_connection(name)
+
+
 def migrate_from_global_variables_to_pgmetadata_section():
     """ Let's migrate from global variables to pgmetadata section in INI file. """
     connection_names = QgsExpressionContextUtils.globalScope().variable("pgmetadata_connection_names")

--- a/pg_metadata/connection_manager.py
+++ b/pg_metadata/connection_manager.py
@@ -3,8 +3,6 @@ __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 __revision__ = "$Format:%H$"
 
-#import logging
-
 from qgis.core import (
     Qgis,
     QgsExpressionContextUtils,
@@ -16,7 +14,6 @@ from qgis.utils import iface
 
 from pg_metadata.qgis_plugin_tools.tools.i18n import tr
 
-#LOGGER = logging.getLogger('pg_metadata')
 
 def check_pgmetadata_is_installed(connection_name: str) -> bool:
     """ Test if a given connection has PgMetadata installed. """
@@ -60,7 +57,7 @@ def add_connection(connection_name: str) -> None:
         settings.setValue("pgmetadata/connection_names", new_string)
 
 
-def store_connections(connection_names: list[str]) -> None:
+def store_connections(connection_names: list) -> None:  # connection_names: list[str]
     """ Store a list of connection names in the QGIS configuration,
         overwriting existing connections """
     reset_connections()
@@ -129,19 +126,20 @@ def connections_list() -> tuple:
             # Todo, we must log something
             # TODO suggestion:
             mess = f'QgsProviderConnectionException when looking for connection {name}.'
-            iface.messageBar().pushMessage(mess, level=Qgis.Critical)  # FIXME: show message bar here or just return message to higher level?
+            iface.messageBar().pushMessage(mess, level=Qgis.Critical)
+            # FIXME: show message bar here or just return message to higher level?
             messages.append(mess)
         else:
             if connection:
                 connections.append(name)
             else:
                 mess = f'Unknown database connection {name} in PgMetadata settings.'
-                iface.messageBar().pushMessage(mess, level=Qgis.Warning)  # FIXME: show message bar here or just return message to higher level?
+                iface.messageBar().pushMessage(mess, level=Qgis.Warning)
+                # FIXME: show message bar here or just return message to higher level?
                 messages.append(mess)
     if messages:
         message = '\n'.join(messages)
     else:
         message = None
-    #LOGGER.info(f'connections_list() -> ({connections}, {message})')
 
     return connections, message

--- a/pg_metadata/connection_manager.py
+++ b/pg_metadata/connection_manager.py
@@ -75,6 +75,29 @@ def settings_connections_names() -> tuple:
     return QgsSettings().value("pgmetadata/connection_names", "", type=str)
 
 
+def validate_connections_names() -> tuple:
+    migrate_from_global_variables_to_pgmetadata_section()
+    metadata = QgsProviderRegistry.instance().providerMetadata('postgres')
+
+    connection_names = settings_connections_names()
+    if not connection_names:
+        return  # no connections is a valid situation
+
+    valid = []
+    invalid = []
+    for name in connection_names.split(';'):
+        try:
+            connection = metadata.findConnection(name)
+        except QgsProviderConnectionException:
+            invalid.append(name)
+        else:
+            if connection:
+                valid.append(name)
+            else:
+                invalid.append(name)
+    return valid, invalid
+
+
 def connections_list() -> tuple:
     """ List of available connections to PostgreSQL database. """
     migrate_from_global_variables_to_pgmetadata_section()

--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -267,9 +267,10 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
             self.set_html_content('PgMetadata', message)
             return
         elif message:
-            LOGGER.critical(message)   # FIXME: Return from here? In case of stale/invalid
-                                       # connection_names we could continue. Invalid connection_names
-                                       # are now removed by connections_list()
+            LOGGER.critical(message)
+            # FIXME: Return from here? In case of stale/invalid
+            # connection_names we could continue. Invalid connection_names
+            # are now removed by connections_list()
 
         # TODO, find the correct connection to query according to the datasource
         # The metadata HTML is wrong if there are many pgmetadata in different databases

--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -278,8 +278,9 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
         for connection_name in connections:
             connection = self.metadata.findConnection(connection_name)
             if not connection:  # FIXME: Can this still happen (see above)?
-                LOGGER.critical("The configuration setting or global variable "
-                                "pgmetadata_connection_names is not correct.")
+                LOGGER.critical(
+                    "The configuration setting or global variable "
+                    "pgmetadata_connection_names is not correct.")
                 self.default_html_content_not_installed()
                 continue
 

--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -267,9 +267,9 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
             self.set_html_content('PgMetadata', message)
             return
         elif message:
-            LOGGER.critical(message) # FIXME: Return from here? In case of stale/invalid
-                                     # connection_names we could continue. Invalid connection_names
-                                     # are now removed by connections_list()
+            LOGGER.critical(message)   # FIXME: Return from here? In case of stale/invalid
+                                       # connection_names we could continue. Invalid connection_names
+                                       # are now removed by connections_list()
 
         # TODO, find the correct connection to query according to the datasource
         # The metadata HTML is wrong if there are many pgmetadata in different databases
@@ -277,7 +277,8 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
         for connection_name in connections:
             connection = self.metadata.findConnection(connection_name)
             if not connection:  # FIXME: Can this still happen (see above)?
-                LOGGER.critical("The configuration setting or global variable pgmetadata_connection_names is not correct.")
+                LOGGER.critical("The configuration setting or global variable "
+                                "pgmetadata_connection_names is not correct.")
                 self.default_html_content_not_installed()
                 continue
 

--- a/pg_metadata/dock.py
+++ b/pg_metadata/dock.py
@@ -266,19 +266,24 @@ class PgMetadataDock(QDockWidget, DOCK_CLASS):
             LOGGER.critical(message)
             self.set_html_content('PgMetadata', message)
             return
+        elif message:
+            LOGGER.critical(message) # FIXME: Return from here? In case of stale/invalid
+                                     # connection_names we could continue. Invalid connection_names
+                                     # are now removed by connections_list()
 
         # TODO, find the correct connection to query according to the datasource
         # The metadata HTML is wrong if there are many pgmetadata in different databases
 
         for connection_name in connections:
             connection = self.metadata.findConnection(connection_name)
-            if not connection:
-                LOGGER.critical("The global variable pgmetadata_connection_names is not correct.")
+            if not connection:  # FIXME: Can this still happen (see above)?
+                LOGGER.critical("The configuration setting or global variable pgmetadata_connection_names is not correct.")
                 self.default_html_content_not_installed()
                 continue
 
             if not check_pgmetadata_is_installed(connection_name):
                 LOGGER.critical(tr('PgMetadata is not installed on {}').format(connection_name))
+                # FIXME: Is this really critical, or just a warning or info?
                 continue
 
             sql = self.sql_for_layer(uri, output_format=OutputFormats.HTML)

--- a/pg_metadata/locator.py
+++ b/pg_metadata/locator.py
@@ -53,7 +53,7 @@ class LocatorFilter(QgsLocatorFilter):
             return
 
         connections, message = connections_list()
-        if not connections:
+        if message or not connections:  # FIXME: log if there are messages or only when no connections?
             self.logMessage(message, Qgis.Critical)
 
         for connection in connections:

--- a/pg_metadata/pg_metadata.py
+++ b/pg_metadata/pg_metadata.py
@@ -3,13 +3,16 @@ __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 
 
-from qgis.core import QgsApplication, QgsSettings
+from qgis.core import QgsApplication
 from qgis.PyQt.QtCore import QCoreApplication, Qt, QTranslator, QUrl
 from qgis.PyQt.QtGui import QDesktopServices, QIcon
 from qgis.PyQt.QtWidgets import QAction, QMessageBox
 from qgis.utils import iface
 
-from pg_metadata.connection_manager import validate_connections_names, store_connections
+from pg_metadata.connection_manager import (
+    store_connections,
+    validate_connections_names,
+)
 from pg_metadata.dock import PgMetadataDock
 from pg_metadata.locator import LocatorFilter
 from pg_metadata.processing.provider import PgMetadataProvider
@@ -83,8 +86,12 @@ class PgMetadata:
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Warning)
         msg.setWindowTitle(tr('PgMetadata: Database connection(s) not available'))
-        msg.setText(tr(f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or no longer available: {invalid_text}'))
-        msg.setInformativeText(tr('Do you want to remove these connection(s) from the PgMetadata settings? (You can also do this later with the ”Set Connections” tool.)'))
+        msg.setText(tr(f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or '
+                       f'no longer available: {invalid_text}'))
+        # FIXME: inserted linebreak because Flake8 failed, but will this mess with Transifex?
+        msg.setInformativeText(tr('Do you want to remove these connection(s) from the PgMetadata settings? '
+                                  '(You can also do this later with the “Set Connections” tool.)'))
+        # FIXME: inserted linebreak because Flake8 failed, but will this mess with Transifex?
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         clicked = msg.exec()
 

--- a/pg_metadata/pg_metadata.py
+++ b/pg_metadata/pg_metadata.py
@@ -9,7 +9,7 @@ from qgis.PyQt.QtGui import QDesktopServices, QIcon
 from qgis.PyQt.QtWidgets import QAction, QMessageBox
 from qgis.utils import iface
 
-from pg_metadata.connection_manager import validate_connections_names
+from pg_metadata.connection_manager import validate_connections_names, store_connections
 from pg_metadata.dock import PgMetadataDock
 from pg_metadata.locator import LocatorFilter
 from pg_metadata.processing.provider import PgMetadataProvider
@@ -89,9 +89,8 @@ class PgMetadata:
         clicked = msg.exec()
 
         if clicked == QMessageBox.Yes:
-            QgsSettings().setValue('pgmetadata/connection_names',
-                                   ';'.join(valid))
             iface.messageBar().pushSuccess(f'PgMetadata', '{n_invalid} invalid connection(s) removed.')
+            store_connections(valid)
         if clicked == QMessageBox.No:
             iface.messageBar().pushInfo('PgMetadata', f'Keeping {n_invalid} invalid connections.')
 

--- a/pg_metadata/pg_metadata.py
+++ b/pg_metadata/pg_metadata.py
@@ -86,11 +86,13 @@ class PgMetadata:
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Warning)
         msg.setWindowTitle(tr('PgMetadata: Database connection(s) not available'))
-        msg.setText(tr(f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or '
-                       f'no longer available: {invalid_text}'))
+        msg.setText(tr(
+            f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or '
+            f'no longer available: {invalid_text}'))
         # FIXME: inserted linebreak because Flake8 failed, but will this mess with Transifex?
-        msg.setInformativeText(tr('Do you want to remove these connection(s) from the PgMetadata settings? '
-                                  '(You can also do this later with the “Set Connections” tool.)'))
+        msg.setInformativeText(tr(
+            'Do you want to remove these connection(s) from the PgMetadata settings? '
+            '(You can also do this later with the “Set Connections” tool.)'))
         # FIXME: inserted linebreak because Flake8 failed, but will this mess with Transifex?
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         clicked = msg.exec()

--- a/pg_metadata/pg_metadata.py
+++ b/pg_metadata/pg_metadata.py
@@ -14,7 +14,7 @@ from pg_metadata.dock import PgMetadataDock
 from pg_metadata.locator import LocatorFilter
 from pg_metadata.processing.provider import PgMetadataProvider
 from pg_metadata.qgis_plugin_tools.tools.custom_logging import setup_logger
-from pg_metadata.qgis_plugin_tools.tools.i18n import setup_translation
+from pg_metadata.qgis_plugin_tools.tools.i18n import setup_translation, tr
 from pg_metadata.qgis_plugin_tools.tools.resources import (
     plugin_path,
     resources_path,
@@ -82,17 +82,17 @@ class PgMetadata:
         invalid_text = ', '.join(invalid)
         msg = QMessageBox()
         msg.setIcon(QMessageBox.Warning)
-        msg.setWindowTitle('PgMetadata: Database connection(s) not available')
-        msg.setText(f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or no longer available: {invalid_text}')
-        msg.setInformativeText('Do you want to remove these connections from the PgMetadata settings? (You can also do this later with the ”Set Connections” tool.)')
+        msg.setWindowTitle(tr('PgMetadata: Database connection(s) not available'))
+        msg.setText(tr(f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or no longer available: {invalid_text}'))
+        msg.setInformativeText(tr('Do you want to remove these connection(s) from the PgMetadata settings? (You can also do this later with the ”Set Connections” tool.)'))
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         clicked = msg.exec()
 
         if clicked == QMessageBox.Yes:
-            iface.messageBar().pushSuccess(f'PgMetadata', '{n_invalid} invalid connection(s) removed.')
+            iface.messageBar().pushSuccess('PgMetadata', tr(f'{n_invalid} invalid connection(s) removed.'))
             store_connections(valid)
         if clicked == QMessageBox.No:
-            iface.messageBar().pushInfo('PgMetadata', f'Keeping {n_invalid} invalid connections.')
+            iface.messageBar().pushInfo('PgMetadata', tr(f'Keeping {n_invalid} invalid connections.'))
 
     @staticmethod
     def open_help():


### PR DESCRIPTION
Instead of `critical` log messages, check for stale database connection (i.e. the connection name is found in PgMetadata’s settings, but no longer exists in Qgis) at startup and give the user the option to delete them.

fix #119 

The function connections_list() shows a message bar every time a connection is not found. This is probably too much, because it appears almost every tiime you do something with the plugin. Also, the message bar call doesn’t seem to play nicely with the locator bar when typing. So I suggest to leave it out. The message box at startup and the “critical” log messages should be enough IMHO.

Also please have a look at the questions marked `FIXME` about “architectural” decisions.