### PR TITLE
Add phone field to contacts, clickable email link to HTLM/dock, schema.table order in locator results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add raster support (contribution from @effjot Florian Jenn)
 * Fix handling of backslashes in file:// links to Windows files (contribution from @effjot Florian Jenn)
+* Add phone number field (contribution from @effjot Florian Jenn)
 
 ## 1.1.1 - 2022-02-14
 

--- a/pg_metadata/install/sql/pgmetadata/20_TABLE_SEQUENCE_DEFAULT.sql
+++ b/pg_metadata/install/sql/pgmetadata/20_TABLE_SEQUENCE_DEFAULT.sql
@@ -27,7 +27,8 @@ CREATE TABLE pgmetadata.contact (
     name text NOT NULL,
     organisation_name text NOT NULL,
     organisation_unit text,
-    email text
+    email text,
+    phone text
 );
 
 

--- a/pg_metadata/install/sql/pgmetadata/30_VIEW.sql
+++ b/pg_metadata/install/sql/pgmetadata/30_VIEW.sql
@@ -52,7 +52,8 @@ CREATE VIEW pgmetadata.v_contact AS
     c.organisation_unit,
     ((((glossary.dict -> 'contact.contact_role'::text) -> dc.contact_role) -> 'label'::text) ->> glossary.locale) AS contact_role,
     dc.contact_role AS contact_role_code,
-    c.email
+    c.email,
+    c.phone
    FROM glossary,
     ((pgmetadata.dataset_contact dc
      JOIN pgmetadata.dataset d ON ((d.id = dc.fk_id_dataset)))

--- a/pg_metadata/install/sql/pgmetadata/70_COMMENT.sql
+++ b/pg_metadata/install/sql/pgmetadata/70_COMMENT.sql
@@ -99,6 +99,10 @@ COMMENT ON COLUMN pgmetadata.contact.organisation_unit IS 'Organisation unit nam
 COMMENT ON COLUMN pgmetadata.contact.email IS 'Email address';
 
 
+-- contact.phone
+COMMENT ON COLUMN pgmetadata.contact.phone IS 'Phone number';
+
+
 -- dataset
 COMMENT ON TABLE pgmetadata.dataset IS 'Main table for storing dataset about PostgreSQL vector layers.';
 

--- a/pg_metadata/locator.py
+++ b/pg_metadata/locator.py
@@ -76,7 +76,7 @@ class LocatorFilter(QgsLocatorFilter):
         # Search items from pgmetadata.dataset
         locale = QgsSettings().value("locale/userLocale", QLocale().name())
         locale = locale.split('_')[0].lower()
-        sql = "SELECT concat(d.title, ' (', d.table_name, '.', d.schema_name, ')') AS displayString,"
+        sql = "SELECT concat(d.title, ' (', d.schema_name, '.',d.table_name, ')') AS displayString,"
         sql += " d.schema_name, d.table_name, d.geometry_type, title"
         sql += " FROM pgmetadata.export_datasets_as_flat_table('{locale}') d"
         sql += " INNER JOIN pgmetadata.v_valid_dataset v"

--- a/pg_metadata/resources/html/contact.html
+++ b/pg_metadata/resources/html/contact.html
@@ -2,6 +2,6 @@
     <td>[% contact_role %]</td>
     <td>[% name %]</td>
     <td>[% organisation_name %] ([% organisation_unit %])</td>
-    <td>[% email %]</td>
+    <td><a href="mailto:[% email %]">[% email %]</a></td>
     <td>[% phone %]</td>
 </tr>

--- a/pg_metadata/resources/html/contact.html
+++ b/pg_metadata/resources/html/contact.html
@@ -3,4 +3,5 @@
     <td>[% name %]</td>
     <td>[% organisation_name %] ([% organisation_unit %])</td>
     <td>[% email %]</td>
+    <td>[% phone %]</td>
 </tr>

--- a/pg_metadata/resources/html/main.html
+++ b/pg_metadata/resources/html/main.html
@@ -92,7 +92,7 @@
             <th>Name</th>
             <th>Organisation</th>
             <th>Email</th>
-            <th>Telefon</th>
+            <th>Phone</th>
         </tr>
         [% meta_contacts %]
     </table>

--- a/pg_metadata/resources/html/main.html
+++ b/pg_metadata/resources/html/main.html
@@ -92,6 +92,7 @@
             <th>Name</th>
             <th>Organisation</th>
             <th>Email</th>
+            <th>Telefon</th>
         </tr>
         [% meta_contacts %]
     </table>


### PR DESCRIPTION
This PR contains 3 small improvments:

* adds a new field for a phone number to contacts (fix #123)
* make email address a clickabel link in HTML template / dock (fix #123)
* also, the order of schema and table names in the locator results are changed to the more common schema-first order (fix #128)
