### PR TITLE
Bugfix incorrect warning about invalid connections (issue #137)

### DIFF
--- a/pg_metadata/connection_manager.py
+++ b/pg_metadata/connection_manager.py
@@ -103,6 +103,8 @@ def settings_connections_names() -> str:
 
 def validate_connections_names() -> tuple:
     migrate_from_global_variables_to_pgmetadata_section()
+    migrate_connection_name_separator()
+    
     metadata = QgsProviderRegistry.instance().providerMetadata('postgres')
 
     connection_names = settings_connections_names()
@@ -111,7 +113,7 @@ def validate_connections_names() -> tuple:
 
     valid = []
     invalid = []
-    for name in connection_names.split(CON_SEPARATOR):
+    for name in connection_names.split(CON_SEPARATOR)[1:]:  # first element is empty, see comment in add_connection()
         try:
             connection = metadata.findConnection(name)
         except QgsProviderConnectionException:
@@ -125,7 +127,12 @@ def validate_connections_names() -> tuple:
 
 
 def connections_list() -> tuple:
-    """ List of available connections to PostgreSQL database. """
+    """ List of available connections to PostgreSQL database.
+    
+    Returns a tuple:
+        * list of connections
+        * list of connection error messages
+    """
     migrate_from_global_variables_to_pgmetadata_section()
     migrate_connection_name_separator()
 
@@ -141,7 +148,7 @@ def connections_list() -> tuple:
 
     connections = list()
     messages = list()
-    for name in connection_names.split(CON_SEPARATOR):
+    for name in connection_names.split(CON_SEPARATOR)[1:]:  # first element is empty, see comment in add_connection()
         try:
             connection = metadata.findConnection(name)
         except QgsProviderConnectionException:

--- a/pg_metadata/connection_manager.py
+++ b/pg_metadata/connection_manager.py
@@ -104,7 +104,7 @@ def settings_connections_names() -> str:
 def validate_connections_names() -> tuple:
     migrate_from_global_variables_to_pgmetadata_section()
     migrate_connection_name_separator()
-    
+
     metadata = QgsProviderRegistry.instance().providerMetadata('postgres')
 
     connection_names = settings_connections_names()
@@ -113,7 +113,8 @@ def validate_connections_names() -> tuple:
 
     valid = []
     invalid = []
-    for name in connection_names.split(CON_SEPARATOR)[1:]:  # first element is empty, see comment in add_connection()
+    # First element of splitted string is empty, see comment in add_connection()
+    for name in connection_names.split(CON_SEPARATOR)[1:]:
         try:
             connection = metadata.findConnection(name)
         except QgsProviderConnectionException:
@@ -128,7 +129,7 @@ def validate_connections_names() -> tuple:
 
 def connections_list() -> tuple:
     """ List of available connections to PostgreSQL database.
-    
+
     Returns a tuple:
         * list of connections
         * list of connection error messages
@@ -148,7 +149,8 @@ def connections_list() -> tuple:
 
     connections = list()
     messages = list()
-    for name in connection_names.split(CON_SEPARATOR)[1:]:  # first element is empty, see comment in add_connection()
+    # First element of splitted string is empty, see comment in add_connection()
+    for name in connection_names.split(CON_SEPARATOR)[1:]:
         try:
             connection = metadata.findConnection(name)
         except QgsProviderConnectionException:

--- a/pg_metadata/pg_metadata.py
+++ b/pg_metadata/pg_metadata.py
@@ -89,11 +89,9 @@ class PgMetadata:
         msg.setText(tr(
             f'{n_invalid} connection(s) listed in PgMetadata’s settings are invalid or '
             f'no longer available: {invalid_text}'))
-        # FIXME: inserted linebreak because Flake8 failed, but will this mess with Transifex?
         msg.setInformativeText(tr(
             'Do you want to remove these connection(s) from the PgMetadata settings? '
             '(You can also do this later with the “Set Connections” tool.)'))
-        # FIXME: inserted linebreak because Flake8 failed, but will this mess with Transifex?
         msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         clicked = msg.exec()
 


### PR DESCRIPTION
In `add_connection()`, there’s an ugly hack for marking settings strings with the new separatore (“Adding the separator at the beginning is an ugly hack to tell new and old strings apart”). In `validate_connections_names()`, the settings string is split by the separator, yielding an empty string as the first element. This in turn is added to the `invalid` list.

With this fix, `validate_connections_names()` ignores the first element, looking only at the “real” connections.

Also, I’ve added a call to `migrate_connection_name_separator()` at the beginning of `validate_connections_names()`, because `validate_connections_names()` is called quite early in the startup process.

Fixes #137