### PR TITLE
Translation for the admin project

### DIFF
--- a/pg_metadata/i18n/pg_metadata_administration_de.ts
+++ b/pg_metadata/i18n/pg_metadata_administration_de.ts
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE" sourcelanguage="en_US">
+<context>
+    <name>project:layers:contact_640d326a_25a7_4b9c_8878_42d1201a8198</name>
+    <message>
+        <source>Contact</source>
+        <translation>Kontakt</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:contact_640d326a_25a7_4b9c_8878_42d1201a8198:fieldaliases</name>
+    <message>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <source>Organisation</source>
+        <translation>Organisation</translation>
+    </message>
+    <message>
+        <source>Organisation unit</source>
+        <translation>Organisationseinheit</translation>
+    </message>
+    <message>
+        <source>Email</source>
+        <translation>E-Mail</translation>
+    </message>
+    <message>
+        <source>phone</source>
+        <translation>Telefon</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_contact_ff2bb406_5b18_4ab7_9fc0_3a25c3aa9675</name>
+    <message>
+        <source>Dataset &lt;-&gt; Contact</source>
+        <translation>Metadaten (Dataset) ↔ Kontakt</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_contact_ff2bb406_5b18_4ab7_9fc0_3a25c3aa9675:fieldaliases</name>
+    <message>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Contact</source>
+        <translation>Kontakt</translation>
+    </message>
+    <message>
+        <source>Dataset</source>
+        <translation>Datensatz</translation>
+    </message>
+    <message>
+        <source>Role</source>
+        <translation>Rolle</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_contact_ff2bb406_5b18_4ab7_9fc0_3a25c3aa9675:fields:contact_role:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd</name>
+    <message>
+        <source>Dataset</source>
+        <translation>Metadaten (Dataset)</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fieldaliases</name>
+    <message>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Unique ID</source>
+        <translation>Unique ID</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Tabelle</translation>
+    </message>
+    <message>
+        <source>Schema</source>
+        <translation>Schema</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <source>Abstract</source>
+        <translation>Zusammenfassung</translation>
+    </message>
+    <message>
+        <source>Categories</source>
+        <translation>Kategorien</translation>
+    </message>
+    <message>
+        <source>Keywords, separated by ,</source>
+        <translation>Schlagworte, durch Komma getrennt</translation>
+    </message>
+    <message>
+        <source>Spatial level</source>
+        <translation>Räumliche Ebene</translation>
+    </message>
+    <message>
+        <source>Minimum optimal scale</source>
+        <translation>Kleinster optimaler Maßstab</translation>
+    </message>
+    <message>
+        <source>Maximum optimal scale</source>
+        <translation>Größter optimaler Maßstab</translation>
+    </message>
+    <message>
+        <source>Date of publication</source>
+        <translation>Veröffentlichungsdatum</translation>
+    </message>
+    <message>
+        <source>Publication frequency</source>
+        <translation>Veröffentlichungshäufigkeit</translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation>Lizenz</translation>
+    </message>
+    <message>
+        <source>Confidentiality</source>
+        <translation>Vertraulichkeit</translation>
+    </message>
+    <message>
+        <source>Feature count</source>
+        <translation>Objektanzahl</translation>
+    </message>
+    <message>
+        <source>Geometry type</source>
+        <translation>Geometrietyp</translation>
+    </message>
+    <message>
+        <source>Projection name</source>
+        <translation>Koordinatensystem</translation>
+    </message>
+    <message>
+        <source>Projection auth Id</source>
+        <translation>KBS Auth_ID</translation>
+    </message>
+    <message>
+        <source>Spatial extent</source>
+        <translation>Ausdehnung</translation>
+    </message>
+    <message>
+        <source>Created at</source>
+        <translatorcomment>Metadatensatz</translatorcomment>
+        <translation>Erstellt</translation>
+    </message>
+    <message>
+        <source>Last updated at</source>
+        <translatorcomment>Metadatensatz</translatorcomment>
+        <translation>Zuletzt geändert</translation>
+    </message>
+    <message>
+        <source>Data last update</source>
+        <translatorcomment>Zieldaten, nicht Metadatensatz</translatorcomment>
+        <translation>Daten zuletzt geändert</translation>
+    </message>
+    <message>
+        <source>Themes</source>
+        <translation>Themen</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:table_name:valuerelationvalue</name>
+    <message>
+        <source>table_name</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:schema_name:valuerelationvalue</name>
+    <message>
+        <source>schema_name</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:categories:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:publication_frequency:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:license:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:confidentiality:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:fields:themes:valuerelationvalue</name>
+    <message>
+        <source>label</source>
+        <translation>label</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:dataset_00c9da4d_d717_48cc_a848_0d4544b019fd:formcontainers</name>
+    <message>
+        <source>Properties</source>
+        <translation>Eigenschaften</translation>
+    </message>
+    <message>
+        <source>Identification</source>
+        <translation>Identifizierung</translation>
+    </message>
+    <message>
+        <source>Publication</source>
+        <translation>Veröffentlichung</translation>
+    </message>
+    <message>
+        <source>Spatial properties</source>
+        <translation>Räumliche Eigenschaften</translation>
+    </message>
+    <message>
+        <source>Metadata</source>
+        <translation>Metadaten</translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation>Kontakte</translation>
+    </message>
+    <message>
+        <source>Links</source>
+        <translation>Links</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:link_6157b282_9882_44f3_b6a1_c133f5595d2a</name>
+    <message>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:link_6157b282_9882_44f3_b6a1_c133f5595d2a:fieldaliases</name>
+    <message>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Name of the ressource</source>
+        <translation>Name der Resource</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <source>URL</source>
+        <translation>URL</translation>
+    </message>
+    <message>
+        <source>Description</source>
+        <translation>Beschreibung</translation>
+    </message>
+    <message>
+        <source>Format</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <source>Mime type</source>
+        <translation>MIME-Typ</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <source>fk_id_dataset</source>
+        <translation>fk_id_dataset</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:link_6157b282_9882_44f3_b6a1_c133f5595d2a:fields:type:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:link_6157b282_9882_44f3_b6a1_c133f5595d2a:fields:mime:valuerelationvalue</name>
+    <message>
+        <source>label_en</source>
+        <translation>label_de</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:html_template_e9cca240_a640_4a7c_a9d0_a181beb9797e</name>
+    <message>
+        <source>HTML templates</source>
+        <translation>HTML-Vorlagen</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:html_template_e9cca240_a640_4a7c_a9d0_a181beb9797e:fieldaliases</name>
+    <message>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Section</source>
+        <translation>Abschnitt</translation>
+    </message>
+    <message>
+        <source>HTML template. Fields must be written as [% &quot;title&quot; %]</source>
+        <translation>HTML-Vorlage. Felder müssen als [% &quot;title&quot; %] geschrieben werden</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:glossary_7235d2fd_01a3_45dc_8321_ea0dc29e55ab</name>
+    <message>
+        <source>Glossary</source>
+        <translation>Glossar</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:glossary_7235d2fd_01a3_45dc_8321_ea0dc29e55ab:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>label_en</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>description_en</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>item_order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>label_fr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>description_fr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>label_it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>description_it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>label_es</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>description_es</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>label_de</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>description_de</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:theme_3d260140_3e41_4dbe_8e79_813f3f5d3d50</name>
+    <message>
+        <source>Theme</source>
+        <translation>Thema</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:theme_3d260140_3e41_4dbe_8e79_813f3f5d3d50:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Code</source>
+        <translation>Code</translation>
+    </message>
+    <message>
+        <source>Label</source>
+        <translation>Bezeichnung</translation>
+    </message>
+    <message>
+        <source>Description</source>
+        <translation>Beschreibung</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_table_list_48c78797_5376_47b8_90e0_8c4f8236fa44</name>
+    <message>
+        <source>Table list</source>
+        <translation>Tabellen-Liste</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_table_list_48c78797_5376_47b8_90e0_8c4f8236fa44:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Schema</source>
+        <translation>Schema</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Tabelle</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_schema_list_140f3a29_ae94_480c_932c_fb47bdad292c</name>
+    <message>
+        <source>Schema list</source>
+        <translation>Schema-Liste</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_schema_list_140f3a29_ae94_480c_932c_fb47bdad292c:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Schema</source>
+        <translation>Schema</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_valid_dataset_4e46ef23_a5aa_441f_b21a_92bb573cbdfd</name>
+    <message>
+        <source>Valid metadata</source>
+        <translation>Gültige Metadaten</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_valid_dataset_4e46ef23_a5aa_441f_b21a_92bb573cbdfd:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>schema_name</source>
+        <translation>Schema</translation>
+    </message>
+    <message>
+        <source>table_name</source>
+        <translation>Tabelle</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_table_comment_from_metadata_d6be195f_86d0_4ef6_af4d_d1fef8a4b7f7</name>
+    <message>
+        <source>Table comments</source>
+        <translation>Tabellen-Kommentare</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_table_comment_from_metadata_d6be195f_86d0_4ef6_af4d_d1fef8a4b7f7:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>table_schema</source>
+        <translation>Schema</translation>
+    </message>
+    <message>
+        <source>table_name</source>
+        <translation>Tabelle</translation>
+    </message>
+    <message>
+        <source>table_comment</source>
+        <translation>Tabellen-Kommentar</translation>
+    </message>
+    <message>
+        <source>table_type</source>
+        <translation>Tabellen-Typ</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_orphan_tables_33b5eba9_96d1_442a_a32e_90a10c6fd2e5</name>
+    <message>
+        <source>Orphan tables</source>
+        <translation>Verwaiste Tabellen</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_orphan_tables_33b5eba9_96d1_442a_a32e_90a10c6fd2e5:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Schema</source>
+        <translation>Schema</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Tabelle</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_orphan_dataset_items_0fbfb83f_0c98_4391_bf51_8b5d8a362a73</name>
+    <message>
+        <source>Orphan metadata</source>
+        <translation>Verwaiste Metadaten</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_orphan_dataset_items_0fbfb83f_0c98_4391_bf51_8b5d8a362a73:fieldaliases</name>
+    <message>
+        <source>id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <source>Schema</source>
+        <translation>Schema</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Tabelle</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_locales_f4efa77e_8eb0_4d5a_809c_d479ae6cc850</name>
+    <message>
+        <source>Locales</source>
+        <translation>Locales</translation>
+    </message>
+</context>
+<context>
+    <name>project:layers:v_locales_f4efa77e_8eb0_4d5a_809c_d479ae6cc850:fieldaliases</name>
+    <message>
+        <source>locale</source>
+        <translation>Locale</translation>
+    </message>
+</context>
+<context>
+    <name>project:layergroups</name>
+    <message>
+        <source>Configuration</source>
+        <translation>Konfiguration</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>Information</translation>
+    </message>
+    <message>
+        <source>Information warnings</source>
+        <translation>Information zu Problemen</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation>Erweitert</translation>
+    </message>
+</context>
+<context>
+    <name>project:relations</name>
+    <message>
+        <source>dataset_contact_fk_id_contact_fkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>dataset_contact_fk_id_dataset_fkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>link_fk_id_dataset_fkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/pg_metadata/processing/administration/create_administration_project.py
+++ b/pg_metadata/processing/administration/create_administration_project.py
@@ -2,6 +2,8 @@ __copyright__ = "Copyright 2020, 3Liz"
 __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 
+from shutil import copyfile
+
 from qgis.core import (
     QgsProcessingParameterFileDestination,
     QgsProcessingParameterProviderConnection,
@@ -107,6 +109,12 @@ class CreateAdministrationProject(BaseProcessingAlgorithm):
         with open(project_file, 'w', encoding='utf8') as fout:
             fout.write(file_data)
 
+        # Copy the translation file
+        lang = 'de'
+        translation_src = template_file.replace('.qgs', f'_{lang}.qm')
+        translation_dst = project_file.replace('.qgs', f'_{lang}.qm')
+        copyfile(translation_src, translation_dst)
+        
         add_connection(connection_name)
 
         msg = tr('QGIS Administration project has been successfully created from the database connection')

--- a/pg_metadata/processing/administration/create_administration_project.py
+++ b/pg_metadata/processing/administration/create_administration_project.py
@@ -8,7 +8,9 @@ from qgis.core import (
     QgsProcessingParameterFileDestination,
     QgsProcessingParameterProviderConnection,
     QgsProviderRegistry,
+    QgsSettings
 )
+from qgis.PyQt.QtCore import QLocale
 
 from pg_metadata.connection_manager import add_connection, connections_list
 from pg_metadata.qgis_plugin_tools.tools.algorithm_processing import (
@@ -110,9 +112,10 @@ class CreateAdministrationProject(BaseProcessingAlgorithm):
             fout.write(file_data)
 
         # Copy the translation file
-        lang = 'de'
-        translation_src = template_file.replace('.qgs', f'_{lang}.qm')
-        translation_dst = project_file.replace('.qgs', f'_{lang}.qm')
+        locale = QgsSettings().value("locale/userLocale", QLocale().name())
+        feedback.pushInfo(f'locale = {locale}')
+        translation_src = template_file.replace('.qgs', f'_{locale}.qm')
+        translation_dst = project_file.replace('.qgs', f'_{locale}.qm')
         copyfile(translation_src, translation_dst)
         
         add_connection(connection_name)

--- a/pg_metadata/processing/administration/create_administration_project.py
+++ b/pg_metadata/processing/administration/create_administration_project.py
@@ -2,7 +2,8 @@ __copyright__ = "Copyright 2020, 3Liz"
 __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 
-from shutil import copyfile
+import os
+import shutil
 
 from qgis.core import (
     QgsProcessingParameterFileDestination,
@@ -116,7 +117,11 @@ class CreateAdministrationProject(BaseProcessingAlgorithm):
         feedback.pushInfo(f'locale = {locale}')
         translation_src = template_file.replace('.qgs', f'_{locale}.qm')
         translation_dst = project_file.replace('.qgs', f'_{locale}.qm')
-        copyfile(translation_src, translation_dst)
+        if locale and os.path.isfile(translation_src):
+            feedback.pushInfo(tr(f'Providing translation for user locale “{locale}”'))
+            shutil.copyfile(translation_src, translation_dst)
+        else:
+            feedback.pushInfo(tr(f'No translation available for user locale “{locale}”'))
         
         add_connection(connection_name)
 


### PR DESCRIPTION
I’ve implemented the approach mentioned in #30: create a .ts file from the admin project and both translate the field aliases, form titles, layer names etc. and the `label_en` glossary field references in the attribute forms. This works nicely, the translated project pulls the glossary terms from the `label_de` column now.

This PR also extends the “create administration project” processing algorithm: The user can select a language (default is the user’s locale) and the corresponding .qm file is copied alongside the target .qgs project file.

At the moment, the .qm files would reside in `resources/projects`, but they could also fit in `i18n`. Also, you would need to add the Transifex part of the translation process.
