### PR TITLE
Use native QGIS API for layer icon

### DIFF
--- a/pg_metadata/locator.py
+++ b/pg_metadata/locator.py
@@ -98,7 +98,11 @@ class LocatorFilter(QgsLocatorFilter):
             result = QgsLocatorResult()
             result.filter = self
             result.displayString = item[0]
-            result.icon = icon_for_geometry_type(item[3])
+            if Qgis.QGIS_VERSION_INT >= 32200:
+                from qgis.core import QgsIconUtils, QgsWkbTypes
+                result.icon = QgsIconUtils.iconForWkbType(QgsWkbTypes.parseType(item[3]))
+            else:
+                result.icon = icon_for_geometry_type(item[3])
             result.userData = {
                 'name': item[4],
                 'connection': connection_name,


### PR DESCRIPTION
The plugin is still compatible 3.16 in the `metadata.txt`.

When we will raise the minimum version (soon, because it's already 3.34...), we can remove the file `tools.py`.

Follow up from #160 